### PR TITLE
Read Kaggle credential (KAGGLE_USERNAME, KAGGLE_KEY) form environment

### DIFF
--- a/opendatasets/utils/kaggle_api.py
+++ b/opendatasets/utils/kaggle_api.py
@@ -19,6 +19,8 @@ def _get_kaggle_key():
 
 def read_kaggle_creds():
     try:
+        if 'KAGGLE_USERNAME' in os.environ.keys() and 'KAGGLE_KEY' in os.environ.keys():
+            return True
         if os.path.exists('./kaggle.json'):
             with open('./kaggle.json', 'r') as f:
                 key = f.read()


### PR DESCRIPTION
### Motivation
While downloading the dataset or accessing **Kaggle** repositories, `kaggle.json` is mandatory. If the file is unavailable in the path, the script will prompt the console to enter `username` & `key`. 
Putting the credentials at every run is exasperating. 

### Solution
This enables the user to set the **Kaggle** credential to the following environment variables (`KAGGLE_USERNAME`, `KAGGLE_KEY`), and the script will automatically read it from the environment.