### PR TITLE
Option to control SSL verification while downloading Kaggle dataset

### DIFF
--- a/opendatasets/__init__.py
+++ b/opendatasets/__init__.py
@@ -10,7 +10,7 @@ from opendatasets.utils.archive import extract_archive
 def download(dataset_id_or_url, data_dir='.', force=False, dry_run=False, **kwargs):
     # Check for a Kaggle dataset URL
     if is_kaggle_url(dataset_id_or_url):
-        return download_kaggle_dataset(dataset_id_or_url, data_dir=data_dir, force=force, dry_run=dry_run)
+        return download_kaggle_dataset(dataset_id_or_url, data_dir=data_dir, force=force, dry_run=dry_run, **kwargs)
 
     # Check for Google Drive URL
     if is_google_drive_url(dataset_id_or_url):

--- a/opendatasets/utils/kaggle_api.py
+++ b/opendatasets/utils/kaggle_api.py
@@ -33,7 +33,7 @@ def read_kaggle_creds():
         return False
 
 
-def download_kaggle_dataset(dataset_url, data_dir, force=False, dry_run=False):
+def download_kaggle_dataset(dataset_url, data_dir, force=False, dry_run=False, verify_ssl=True):
     dataset_id = get_kaggle_dataset_id(dataset_url)
     id = dataset_id.split('/')[1]
     target_dir = os.path.join(data_dir, id)
@@ -51,6 +51,10 @@ def download_kaggle_dataset(dataset_url, data_dir, force=False, dry_run=False):
     if not dry_run:
         from kaggle import api
         api.authenticate()
+        from kaggle import rest
+        api.api_client.configuration.verify_ssl = verify_ssl
+        api.api_client.rest_client = rest.RESTClientObject(api.api_client.configuration)
+        
         if dataset_id.split('/')[0] == 'competitions' or dataset_id.split('/')[0] == 'c':
             api.competition_download_files(
                 id,

--- a/test/test_kaggle_download.py
+++ b/test/test_kaggle_download.py
@@ -1,0 +1,20 @@
+import os
+import unittest
+
+
+class MyTestCase(unittest.TestCase):
+    
+    def test_verify_ssl(self):
+        import opendatasets as od
+        kaggle_dataset_url = r"https://www.kaggle.com/datasets/akashsharma0105/phone-usage-in-india"
+        od.download(kaggle_dataset_url, verify_ssl=False)
+        exists = os.path.exists("phone-usage-in-india")
+        # test
+        self.assertEqual(exists, True)
+        # cleanup
+        import shutil
+        shutil.rmtree("phone-usage-in-india")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation

In certain systems, while downloading **Kaggle dataset,** we face the following error: `SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed `.

### Solution
A new optional parameter is introduced in `opendatasets.download(kaggle_dataset_url, verify_ssl=False)` where one can control ssl verification while downloading. By default `verify_ssl=True`